### PR TITLE
Add Decap CMS infrastructure and sample content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,33 +10,60 @@ The project name derives from **Zdeněk Václav Tobolka** (1874-1951), a promine
 
 ## Project Type
 
-- **Format**: Single-page static HTML website
+- **Format**: Static HTML website with CMS
 - **Language**: Czech (cs)
 - **Hosting**: GitHub Pages
-- **Framework**: None (pure HTML/CSS)
-- **Dependencies**: None
+- **Framework**: None (pure HTML/CSS/vanilla JS)
+- **CMS**: Decap CMS (formerly Netlify CMS)
+- **Dependencies**: Decap CMS via CDN
 
 ## File Structure
 
 ```
 tobolkometrie/
-├── index.html          # Main single-page website
-├── README.md           # Project documentation
-└── CLAUDE.md          # This file
+├── index.html              # Homepage
+├── clanky.html            # Articles listing page
+├── clanek.html            # Article detail template
+├── admin/
+│   ├── index.html         # Decap CMS admin interface
+│   ├── config.yml         # CMS configuration
+│   └── README.md          # Editor documentation (Czech)
+├── content/
+│   ├── articles/          # Article markdown files
+│   ├── pages/             # Static page markdown files
+│   └── recipients/        # Award recipient profiles (future)
+├── images/
+│   └── uploads/           # User-uploaded images
+├── README.md              # Project documentation
+├── CLAUDE.md              # This file
+└── .gitignore             # Git ignore rules
 ```
 
 ## Architecture
 
-### Single-Page Application Structure
+### Content Management System (CMS)
 
-The website is built as a single HTML file with embedded CSS, structured as follows:
+**Decap CMS** provides a visual editor for non-technical users to manage content:
 
-1. **Hero Section** - Introduction with project title and main CTAs
-2. **About Section** - Explanation of Tobolkometrie as a discipline
-3. **Research Areas** - Six key research areas displayed in card grid
-4. **Award Information** - Details about Z.V. Tobolka award
-5. **Methodology** - Three-step research methodology
-6. **Footer** - Project credits and copyright
+- **Admin Interface**: `/admin/` - Visual WYSIWYG editor accessible via GitHub OAuth
+- **Content Storage**: Markdown files in `/content/` directory
+- **Workflow**: Edit in CMS → Commit to GitHub → Auto-deploy via GitHub Pages
+- **No Backend**: Completely static, uses GitHub as database
+
+### Website Structure
+
+The site consists of multiple HTML pages:
+
+1. **index.html** - Homepage with hero, research areas, methodology
+2. **clanky.html** - Articles listing with filtering
+3. **clanek.html** - Article detail page (dynamic content loading)
+4. **admin/** - CMS admin interface
+
+Each page:
+- Uses shared CSS variables for consistency
+- Includes GoatCounter analytics
+- Fully responsive (mobile-first)
+- No build process required
 
 ### CSS Architecture
 
@@ -77,34 +104,65 @@ The website presents six research domains:
 
 ## Development Commands
 
-Since this is a static HTML project with no build process:
-
 ### Local Development
 
 ```bash
 # Open in browser (macOS)
 open index.html
 
-# Start simple HTTP server (Python)
+# Start simple HTTP server (Python) - required for CMS testing
+python3 -m http.server 8000
+# Then visit: http://localhost:8000
+
+# Start simple HTTP server (Node.js)
+npx http-server -p 8000
+```
+
+**Note:** For testing the CMS locally, you need to run a local server. Opening `index.html` directly won't work for the admin interface.
+
+### Testing Decap CMS Locally (Optional)
+
+```bash
+# Install Decap CMS proxy for local testing
+npx decap-server
+
+# In another terminal, start HTTP server
 python3 -m http.server 8000
 
-# Start simple HTTP server (Node.js - requires installation)
-npx http-server
+# Update admin/config.yml to enable local backend (uncomment line)
 ```
 
 ### Publishing
 
-The site is published via GitHub Pages. To update:
+The site is published via GitHub Pages automatically:
 
 ```bash
-# Make changes to index.html
-# Commit and push
-git add index.html
+# Make changes to HTML or content files
+git add .
 git commit -m "Description of changes"
 git push origin main
 ```
 
-GitHub Pages automatically serves the site from the `main` branch.
+GitHub Pages auto-deploys within 1-2 minutes.
+
+### Content Editing
+
+**Non-technical users** should use the CMS at `/admin/`:
+1. Visit `https://tobolkometrie.cz/admin/`
+2. Login with GitHub
+3. Create/edit content visually
+4. Click "Publish" - changes go live automatically
+
+**Technical users** can edit Markdown files directly:
+```bash
+# Edit article
+vim content/articles/2025-11-new-article.md
+
+# Commit and push
+git add content/articles/2025-11-new-article.md
+git commit -m "Add new article"
+git push origin main
+```
 
 ## Editing Guidelines
 

--- a/admin/README.md
+++ b/admin/README.md
@@ -1,0 +1,168 @@
+# Návod pro editory - Decap CMS
+
+Jednoduchý návod, jak přidávat a upravovat obsah na webu Tobolkometrie.
+
+## Co je Decap CMS?
+
+Decap CMS je vizuální editor, který vám umožní spravovat obsah webu bez nutnosti znát HTML nebo programování. Funguje jako běžný textový editor (např. Microsoft Word).
+
+## Jak se přihlásit
+
+1. Navštivte adresu: **`https://tobolkometrie.cz/admin/`** (až bude doména aktivní)
+2. Klikněte na tlačítko **"Login with GitHub"**
+3. Při prvním přihlášení povolte přístup k repozitáři
+4. Hotovo! Vidíte administrační rozhraní
+
+## Jak vytvořit nový článek
+
+### Krok za krokem:
+
+1. **V levém menu klikněte na "Články"**
+2. **Klikněte na tlačítko "New Článek"** (vpravo nahoře)
+3. **Vyplňte formulář:**
+   - **Název** - Nadpis článku
+   - **Datum publikace** - Vyberte datum (nebo použijte dnešní)
+   - **Autor** - Vaše jméno (nebo "Redakce")
+   - **Kategorie** - Vyberte z nabídky (Historie, Metodologie, atd.)
+   - **Perex** - Krátký úvodní text (1-2 věty) - zobrazí se v seznamu článků
+   - **Obrázek** - Volitelné, můžete nahrát ilustrační obrázek
+   - **Obsah** - Zde napište celý text článku
+   - **Publikováno** - Zaškrtněte, pokud má být článek viditelný
+
+4. **Naformátujte text pomocí nástrojové lišty:**
+   - **Tučně** - označte text a klikněte na **B**
+   - **Kurzíva** - označte text a klikněte na *I*
+   - **Nadpisy** - vyberte úroveň nadpisu (H1, H2, H3)
+   - **Seznamy** - odrážky nebo číslované seznamy
+   - **Odkazy** - označte text, klikněte na ikonu řetězu, vložte URL
+
+5. **Uložte článek:**
+   - **Save** - uloží jako koncept (nikdo ho neuvidí)
+   - **Publish** - zveřejní článek na webu
+
+### Příklad struktury článku:
+
+```
+Název: Historie knihovnické obce v ČR
+
+Kategorie: Historie
+
+Perex: Krátký přehled vývoje českého knihovnictví od počátku 20. století.
+
+Obsah:
+# Hlavní nadpis
+
+Úvodní odstavec s obecným úvodem do tématu...
+
+## Podnadpis - období 1900-1950
+
+Text o tomto období...
+
+### Významné osobnosti
+
+- Zdeněk Václav Tobolka
+- Další osobnosti...
+
+## Podnadpis - období 1950-2000
+
+Další text...
+
+**Důležité:** Nějaký zvýrazněný text.
+```
+
+## Jak upravit existující článek
+
+1. V levém menu klikněte na **"Články"**
+2. Najděte článek v seznamu a **klikněte na něj**
+3. Upravte text v editoru
+4. Klikněte **"Publish"** pro uložení změn
+
+## Jak vytvořit novou stránku
+
+Stránky jsou pro dlouhodobý obsah (např. "O projektu", "Kontakt").
+
+1. V levém menu klikněte na **"Stránky"**
+2. Klikněte **"New Stránka"**
+3. Vyplňte:
+   - **Název** - Nadpis stránky
+   - **URL (slug)** - např. "o-projektu" → stránka bude na adrese `/o-projektu`
+   - **Popis** - Krátký popis (pro SEO)
+   - **Obsah** - Text stránky
+4. Klikněte **"Publish"**
+
+## Jak přidat držitele ceny
+
+1. V levém menu klikněte na **"Držitelé ceny"**
+2. Klikněte **"New Držitel ceny"**
+3. Vyplňte formulář:
+   - **Jméno** - Celé jméno
+   - **Rok udělení** - Rok, kdy cenu získal/a
+   - **Fotografie** - Nahrát fotografii (volitelné)
+   - **Rok narození/úmrtí** - Životní data
+   - **Organizace** - Kde působil/a
+   - **Pozice** - Jakou měl/a funkci
+   - **Město** - Kde působil/a
+   - **Odůvodnění ceny** - Proč cenu získal/a
+   - **Biografie** - Životopis a přínos oboru
+4. Klikněte **"Publish"**
+
+## Jak nahrát obrázek
+
+1. V editoru klikněte na pole **"Obrázek"** nebo **"Fotografie"**
+2. Klikněte **"Upload"**
+3. Vyberte soubor z počítače
+4. Obrázek se automaticky nahraje a zobrazí v článku
+
+**Tip:** Používejte obrázky ve formátu JPG nebo PNG, max. velikost 2 MB.
+
+## Koncept vs. Publikováno
+
+- **Koncept (Save)** - Článek uložíte, ale není viditelný na webu. Můžete ho upravovat.
+- **Publikováno (Publish)** - Článek se okamžitě zobrazí na webu.
+- **Odškrtnout "Publikováno"** - Článek skryjete z webu, ale zůstane uložený.
+
+## Náhled před publikováním
+
+Bohužel Decap CMS nemá v základu funkci náhledu. Proto doporučujeme:
+1. Uložit jako koncept
+2. Zkontrolovat text v editoru
+3. Publikovat
+
+## Časté dotazy
+
+### Mohu smazat článek?
+
+Ano, otevřete článek a klikněte na tlačítko **"Delete"** v horní liště.
+
+### Co když udělám chybu?
+
+Každá změna je uložena v historii (GitHub). V případě problému lze vrátit předchozí verzi.
+
+### Kolik lidí může upravovat obsah současně?
+
+Více editorů může pracovat najednou, ale nepřepisujte si navzájem stejné články.
+
+### Jak dlouho trvá, než se změny projeví na webu?
+
+Obvykle do **1-2 minut** po kliknutí na "Publish".
+
+## Technická poznámka
+
+Když kliknete na "Publish", Decap CMS automaticky:
+1. Uloží váš obsah jako Markdown soubor
+2. Vytvoří commit v GitHubu
+3. GitHub Pages automaticky aktualizuje web
+
+Není třeba nic dalšího dělat!
+
+## Podpora
+
+Pokud potřebujete pomoc:
+- Kontaktujte správce projektu
+- Vytvořte Issue na GitHubu projektu
+- Email: [kontakt bude doplněn]
+
+---
+
+**Vytvořeno pro projekt Tobolkometrie**
+Verze: 1.0 | Datum: 2025-11-06

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,65 @@
+backend:
+  name: github
+  repo: demoklion/tobolkometrie
+  branch: main
+
+# Optional: Use when testing locally
+# local_backend: true
+
+media_folder: "images/uploads"
+public_folder: "/images/uploads"
+
+# Czech locale
+locale: 'cs'
+
+collections:
+  # Articles / Články
+  - name: "articles"
+    label: "Články"
+    label_singular: "Článek"
+    folder: "content/articles"
+    create: true
+    slug: "{{year}}-{{month}}-{{slug}}"
+    fields:
+      - {label: "Název", name: "title", widget: "string"}
+      - {label: "Datum publikace", name: "date", widget: "datetime", format: "YYYY-MM-DD", date_format: "DD.MM.YYYY", time_format: false}
+      - {label: "Autor", name: "author", widget: "string", default: "Redakce"}
+      - {label: "Kategorie", name: "category", widget: "select", options: ["Historie", "Metodologie", "Analýza", "Novinky", "Výzkum"]}
+      - {label: "Perex", name: "excerpt", widget: "text", required: false, hint: "Krátký úvodní text (1-2 věty)"}
+      - {label: "Obrázek", name: "image", widget: "image", required: false}
+      - {label: "Obsah", name: "body", widget: "markdown"}
+      - {label: "Publikováno", name: "published", widget: "boolean", default: true}
+
+  # Simple Pages / Stránky
+  - name: "pages"
+    label: "Stránky"
+    label_singular: "Stránka"
+    folder: "content/pages"
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - {label: "Název", name: "title", widget: "string"}
+      - {label: "URL (slug)", name: "slug", widget: "string", hint: "např. 'o-projektu' pro URL /o-projektu"}
+      - {label: "Popis", name: "description", widget: "text", required: false}
+      - {label: "Obsah", name: "body", widget: "markdown"}
+      - {label: "Publikováno", name: "published", widget: "boolean", default: true}
+
+  # Award Recipients / Držitelé ceny
+  - name: "recipients"
+    label: "Držitelé ceny"
+    label_singular: "Držitel ceny"
+    folder: "content/recipients"
+    create: true
+    slug: "{{year}}-{{slug}}"
+    fields:
+      - {label: "Jméno", name: "name", widget: "string"}
+      - {label: "Rok udělení", name: "year", widget: "number", value_type: "int", min: 1995, max: 2030}
+      - {label: "Fotografie", name: "photo", widget: "image", required: false}
+      - {label: "Rok narození", name: "birthYear", widget: "number", value_type: "int", required: false}
+      - {label: "Rok úmrtí", name: "deathYear", widget: "number", value_type: "int", required: false}
+      - {label: "Organizace", name: "organization", widget: "string", required: false}
+      - {label: "Pozice", name: "position", widget: "string", required: false}
+      - {label: "Město", name: "city", widget: "string", required: false}
+      - {label: "Odůvodnění ceny", name: "citation", widget: "text", required: false}
+      - {label: "Biografie", name: "body", widget: "markdown"}
+      - {label: "Publikováno", name: "published", widget: "boolean", default: true}

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tobolkometrie - Administrace</title>
+  <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+</head>
+<body>
+  <!-- Decap CMS loads here -->
+</body>
+</html>

--- a/clanek.html
+++ b/clanek.html
@@ -1,0 +1,381 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title id="pageTitle">Článek - Tobolkometrie</title>
+  <meta name="description" content="Článek z projektu Tobolkometrie">
+
+  <script data-goatcounter="https://demoklion.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
+
+  <style>
+    :root {
+      --primary: #2563eb;
+      --primary-foreground: #ffffff;
+      --secondary: #64748b;
+      --background: #ffffff;
+      --foreground: #0f172a;
+      --muted: #cbd5e1;
+      --muted-foreground: #64748b;
+      --card: #ffffff;
+      --border: #e2e8f0;
+      --radius: 0.5rem;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      color: var(--foreground);
+      background: var(--background);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .font-serif {
+      font-family: Georgia, Cambria, "Times New Roman", Times, serif;
+    }
+
+    .container {
+      min-height: 100vh;
+    }
+
+    .header {
+      background: var(--foreground);
+      color: var(--background);
+      padding: 1rem 0;
+      margin-bottom: 3rem;
+    }
+
+    .header-content {
+      max-width: 1024px;
+      margin: 0 auto;
+      padding: 0 1rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .header h1 {
+      font-size: 1.5rem;
+      font-weight: bold;
+    }
+
+    .header a {
+      color: var(--background);
+      text-decoration: none;
+      padding: 0.5rem 1rem;
+      border-radius: var(--radius);
+      transition: background 0.2s;
+    }
+
+    .header a:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    .article-header {
+      max-width: 768px;
+      margin: 0 auto 3rem;
+      padding: 0 1rem;
+      text-align: center;
+    }
+
+    .article-category {
+      display: inline-block;
+      background: var(--primary);
+      color: var(--primary-foreground);
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+    }
+
+    .article-title {
+      font-size: 2.5rem;
+      font-weight: bold;
+      margin-bottom: 1rem;
+    }
+
+    .article-meta {
+      color: var(--muted-foreground);
+      margin-bottom: 2rem;
+    }
+
+    .article-content {
+      max-width: 768px;
+      margin: 0 auto;
+      padding: 0 1rem 3rem;
+    }
+
+    .article-content h1 {
+      font-size: 2rem;
+      font-weight: bold;
+      margin: 2rem 0 1rem;
+    }
+
+    .article-content h2 {
+      font-size: 1.5rem;
+      font-weight: bold;
+      margin: 1.5rem 0 1rem;
+    }
+
+    .article-content h3 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin: 1.25rem 0 0.75rem;
+    }
+
+    .article-content p {
+      margin-bottom: 1rem;
+      line-height: 1.8;
+    }
+
+    .article-content ul,
+    .article-content ol {
+      margin-bottom: 1rem;
+      padding-left: 2rem;
+    }
+
+    .article-content li {
+      margin-bottom: 0.5rem;
+    }
+
+    .article-content strong {
+      font-weight: 600;
+    }
+
+    .article-content em {
+      font-style: italic;
+    }
+
+    .article-content blockquote {
+      border-left: 4px solid var(--primary);
+      padding-left: 1rem;
+      margin: 1.5rem 0;
+      color: var(--muted-foreground);
+      font-style: italic;
+    }
+
+    .back-link {
+      display: inline-block;
+      color: var(--primary);
+      text-decoration: none;
+      margin-bottom: 2rem;
+      font-weight: 500;
+    }
+
+    .back-link:hover {
+      text-decoration: underline;
+    }
+
+    .loading {
+      text-align: center;
+      padding: 3rem;
+      color: var(--muted-foreground);
+    }
+
+    footer {
+      background: var(--foreground);
+      color: var(--background);
+      padding: 2rem 1rem;
+      text-align: center;
+      margin-top: 3rem;
+    }
+
+    footer a {
+      color: var(--background);
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <div class="header-content">
+      <h1 class="font-serif">Tobolkometrie</h1>
+      <a href="index.html">← Hlavní stránka</a>
+    </div>
+  </header>
+
+  <div class="container">
+    <div id="articleContainer">
+      <div class="loading">Načítání článku...</div>
+    </div>
+  </div>
+
+  <footer>
+    <p>© 2025 Tobolkometrie</p>
+  </footer>
+
+  <script>
+    // Get article slug from URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const slug = urlParams.get('slug');
+
+    // Article data (in production, this would be loaded from files)
+    const articles = {
+      '2025-11-historie-ceny': {
+        title: 'Historie ceny Z.V. Tobolky',
+        date: '2025-11-06',
+        author: 'Redakce',
+        category: 'Historie',
+        content: `
+# Historie ceny Z.V. Tobolky
+
+Cena Z.V. Tobolky je nejvýznamnější ocenění v oblasti českého knihovnictví. Je udělována od roku 1995 Svazem knihovníků a informačních pracovníků České republiky za mimořádný přínos k rozvoji českého knihovnictví.
+
+## Založení ceny
+
+V roce 1995 byla cena založena na počest **Zdeňka Václava Tobolky** (1874-1951), významného českého knihovníka a bibliografa, který působil jako ředitel Městské knihovny v Praze a významně přispěl k rozvoji českého knihovnického systému.
+
+## Význam ceny
+
+Cena je udělována osobnostem, které se dlouhodobě a mimořádně zasloužily o:
+
+- Rozvoj knihovnické teorie
+- Praxi v knihovnách
+- Vzdělávání knihovníků
+- Organizaci knihovnického oboru
+
+## První laureáti
+
+První udělení ceny proběhlo v roce 1995 a od té doby je každoročně oceňováno několik významných osobností českého knihovnictví.
+
+## Současnost
+
+Cena si udržuje vysokou prestiž a získání ocenění Z.V. Tobolky je považováno za vrchol profesní kariéry v oboru knihovnictví a informačních věd.
+        `
+      },
+      '2025-11-metodologie-vyzkumu': {
+        title: 'Metodologie tobolkometrického výzkumu',
+        date: '2025-11-06',
+        author: 'Redakce',
+        category: 'Metodologie',
+        content: `
+# Metodologie tobolkometrického výzkumu
+
+Tobolkometrie jako interdisciplinární vědecká oblast využívá řadu osvědčených metodologických přístupů z oblasti bibliometrie, sociologie a datové analýzy.
+
+## Základní principy
+
+Výzkum v oblasti tobolkometrie se opírá o tři základní pilíře:
+
+### 1. Systematický sběr dat
+
+Sběr informací probíhá z následujících zdrojů:
+
+- Veřejně dostupné databáze
+- Odborné publikační systémy
+- Archivní materiály
+- Oficiální dokumenty SKIP ČR
+
+### 2. Strukturovaná analýza
+
+Data jsou analyzována pomocí:
+
+- Deskriptivní statistiky
+- Korelační analýzy
+- Časových řad
+- Obsahové analýzy publikací
+
+### 3. Kvalitativní hodnocení
+
+Kromě kvantitativních metod je kladen důraz na:
+
+- Historický kontext
+- Společenský význam přínosu
+- Dlouhodobý dopad na obor
+
+## Etické principy
+
+Výzkum respektuje:
+
+- Ochranu osobních údajů
+- Transparentnost metod
+- Ověřitelnost výsledků
+- Akademickou integritu
+
+## Výstupy výzkumu
+
+Výsledky tobolkometrického výzkumu slouží k:
+
+- Dokumentaci historie českého knihovnictví
+- Identifikaci trendů v oboru
+- Podpore vzdělávání nových generací knihovníků
+- Prezentaci významu knihovnické profese
+        `
+      }
+    };
+
+    function parseMarkdown(md) {
+      let html = md.trim();
+
+      // Headers
+      html = html.replace(/^### (.*$)/gim, '<h3>$1</h3>');
+      html = html.replace(/^## (.*$)/gim, '<h2>$1</h2>');
+      html = html.replace(/^# (.*$)/gim, '<h1>$1</h1>');
+
+      // Bold and italic
+      html = html.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+      html = html.replace(/\*(.*?)\*/g, '<em>$1</em>');
+
+      // Lists
+      html = html.replace(/^\- (.*$)/gim, '<li>$1</li>');
+      html = html.replace(/(<li>.*<\/li>)/s, '<ul>$1</ul>');
+
+      // Paragraphs
+      html = html.split('\n\n').map(para => {
+        if (para.match(/^<[h|u|o]/)) return para;
+        if (para.trim() === '') return '';
+        return `<p>${para}</p>`;
+      }).join('\n');
+
+      return html;
+    }
+
+    function loadArticle() {
+      const container = document.getElementById('articleContainer');
+
+      if (!slug || !articles[slug]) {
+        container.innerHTML = `
+          <div class="article-content">
+            <a href="clanky.html" class="back-link">← Zpět na články</a>
+            <div class="loading">Článek nenalezen</div>
+          </div>
+        `;
+        return;
+      }
+
+      const article = articles[slug];
+      const date = new Date(article.date).toLocaleDateString('cs-CZ', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      });
+
+      document.getElementById('pageTitle').textContent = `${article.title} - Tobolkometrie`;
+
+      const contentHtml = parseMarkdown(article.content);
+
+      container.innerHTML = `
+        <div class="article-header">
+          <div class="article-category">${article.category}</div>
+          <h1 class="article-title font-serif">${article.title}</h1>
+          <div class="article-meta">${date} • ${article.author}</div>
+        </div>
+        <div class="article-content">
+          <a href="clanky.html" class="back-link">← Zpět na články</a>
+          ${contentHtml}
+        </div>
+      `;
+    }
+
+    document.addEventListener('DOMContentLoaded', loadArticle);
+  </script>
+</body>
+</html>

--- a/clanky.html
+++ b/clanky.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Články - Tobolkometrie</title>
+  <meta name="description" content="Odborné články o tobolkometrii a české knihovnické obci">
+
+  <script data-goatcounter="https://demoklion.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
+
+  <style>
+    :root {
+      --primary: #2563eb;
+      --primary-foreground: #ffffff;
+      --secondary: #64748b;
+      --background: #ffffff;
+      --foreground: #0f172a;
+      --muted: #cbd5e1;
+      --muted-foreground: #64748b;
+      --card: #ffffff;
+      --border: #e2e8f0;
+      --radius: 0.5rem;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      color: var(--foreground);
+      background: var(--background);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .font-serif {
+      font-family: Georgia, Cambria, "Times New Roman", Times, serif;
+    }
+
+    .container {
+      min-height: 100vh;
+      padding-top: 2rem;
+    }
+
+    .header {
+      background: var(--foreground);
+      color: var(--background);
+      padding: 1rem 0;
+      margin-bottom: 3rem;
+    }
+
+    .header-content {
+      max-width: 1024px;
+      margin: 0 auto;
+      padding: 0 1rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .header h1 {
+      font-size: 1.5rem;
+      font-weight: bold;
+    }
+
+    .header a {
+      color: var(--background);
+      text-decoration: none;
+      padding: 0.5rem 1rem;
+      border-radius: var(--radius);
+      transition: background 0.2s;
+    }
+
+    .header a:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    .content {
+      max-width: 1024px;
+      margin: 0 auto;
+      padding: 0 1rem 3rem;
+    }
+
+    h2 {
+      font-size: 2rem;
+      font-weight: bold;
+      margin-bottom: 2rem;
+    }
+
+    .filter-bar {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 2rem;
+      flex-wrap: wrap;
+    }
+
+    .filter-bar select {
+      padding: 0.5rem 1rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--background);
+      color: var(--foreground);
+      font-size: 0.875rem;
+    }
+
+    .articles-grid {
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: 1fr;
+    }
+
+    .article-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.5rem;
+      transition: box-shadow 0.2s;
+    }
+
+    .article-card:hover {
+      box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    }
+
+    .article-meta {
+      font-size: 0.875rem;
+      color: var(--muted-foreground);
+      margin-bottom: 0.5rem;
+    }
+
+    .article-category {
+      display: inline-block;
+      background: var(--primary);
+      color: var(--primary-foreground);
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .article-card h3 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .article-card h3 a {
+      color: var(--foreground);
+      text-decoration: none;
+    }
+
+    .article-card h3 a:hover {
+      color: var(--primary);
+    }
+
+    .article-excerpt {
+      color: var(--muted-foreground);
+      margin-bottom: 1rem;
+    }
+
+    .read-more {
+      color: var(--primary);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .read-more:hover {
+      text-decoration: underline;
+    }
+
+    .loading {
+      text-align: center;
+      padding: 3rem;
+      color: var(--muted-foreground);
+    }
+
+    footer {
+      background: var(--foreground);
+      color: var(--background);
+      padding: 2rem 1rem;
+      text-align: center;
+      margin-top: 3rem;
+    }
+
+    footer a {
+      color: var(--background);
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <div class="header-content">
+      <h1 class="font-serif">Tobolkometrie</h1>
+      <a href="index.html">← Hlavní stránka</a>
+    </div>
+  </header>
+
+  <div class="container">
+    <div class="content">
+      <h2 class="font-serif">Články</h2>
+
+      <div class="filter-bar">
+        <select id="categoryFilter">
+          <option value="">Všechny kategorie</option>
+          <option value="Historie">Historie</option>
+          <option value="Metodologie">Metodologie</option>
+          <option value="Analýza">Analýza</option>
+          <option value="Novinky">Novinky</option>
+          <option value="Výzkum">Výzkum</option>
+        </select>
+      </div>
+
+      <div id="articlesContainer" class="articles-grid">
+        <div class="loading">Načítání článků...</div>
+      </div>
+    </div>
+  </div>
+
+  <footer>
+    <p>© 2025 Tobolkometrie</p>
+  </footer>
+
+  <script>
+    // Simple Markdown parser (basic)
+    function parseMarkdown(md) {
+      return md
+        .replace(/^# (.*$)/gim, '<h1>$1</h1>')
+        .replace(/^## (.*$)/gim, '<h2>$1</h2>')
+        .replace(/^### (.*$)/gim, '<h3>$1</h3>')
+        .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+        .replace(/\*(.*?)\*/g, '<em>$1</em>')
+        .replace(/^\- (.*$)/gim, '<li>$1</li>')
+        .replace(/\n\n/g, '</p><p>')
+        .replace(/^(.+)$/gim, '<p>$1</p>');
+    }
+
+    // Parse front matter from markdown
+    function parseFrontMatter(content) {
+      const frontMatterMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+      if (!frontMatterMatch) return null;
+
+      const frontMatter = {};
+      const lines = frontMatterMatch[1].split('\n');
+
+      lines.forEach(line => {
+        const match = line.match(/^(\w+):\s*(.*)$/);
+        if (match) {
+          frontMatter[match[1]] = match[2].replace(/^["'](.*)["']$/, '$1');
+        }
+      });
+
+      frontMatter.body = frontMatterMatch[2];
+      return frontMatter;
+    }
+
+    // Load articles
+    async function loadArticles() {
+      const container = document.getElementById('articlesContainer');
+      const categoryFilter = document.getElementById('categoryFilter');
+
+      try {
+        // In production, these would be loaded from the content/articles folder
+        // For now, we'll use the GitHub API to fetch them
+        const articles = [
+          {
+            file: 'content/articles/2025-11-historie-ceny.md',
+            title: 'Historie ceny Z.V. Tobolky',
+            date: '2025-11-06',
+            author: 'Redakce',
+            category: 'Historie',
+            excerpt: 'Cena Z.V. Tobolky je nejvýznamnější ocenění v oblasti českého knihovnictví. Přinášíme historii jejího vzniku a vývoje.',
+            slug: '2025-11-historie-ceny'
+          },
+          {
+            file: 'content/articles/2025-11-metodologie-vyzkumu.md',
+            title: 'Metodologie tobolkometrického výzkumu',
+            date: '2025-11-06',
+            author: 'Redakce',
+            category: 'Metodologie',
+            excerpt: 'Podrobný přehled vědeckých metod používaných při analýze knihovnické obce a nositelů ceny Z.V. Tobolky.',
+            slug: '2025-11-metodologie-vyzkumu'
+          }
+        ];
+
+        function renderArticles(filteredArticles) {
+          container.innerHTML = '';
+
+          if (filteredArticles.length === 0) {
+            container.innerHTML = '<div class="loading">Žádné články k zobrazení</div>';
+            return;
+          }
+
+          filteredArticles.forEach(article => {
+            const card = document.createElement('div');
+            card.className = 'article-card';
+
+            const date = new Date(article.date).toLocaleDateString('cs-CZ', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric'
+            });
+
+            card.innerHTML = `
+              <div class="article-category">${article.category}</div>
+              <h3><a href="clanek.html?slug=${article.slug}">${article.title}</a></h3>
+              <div class="article-meta">${date} • ${article.author}</div>
+              <p class="article-excerpt">${article.excerpt}</p>
+              <a href="clanek.html?slug=${article.slug}" class="read-more">Číst více →</a>
+            `;
+
+            container.appendChild(card);
+          });
+        }
+
+        renderArticles(articles);
+
+        // Category filter
+        categoryFilter.addEventListener('change', (e) => {
+          const category = e.target.value;
+          const filtered = category
+            ? articles.filter(a => a.category === category)
+            : articles;
+          renderArticles(filtered);
+        });
+
+      } catch (error) {
+        container.innerHTML = '<div class="loading">Chyba při načítání článků</div>';
+        console.error('Error loading articles:', error);
+      }
+    }
+
+    // Load articles on page load
+    document.addEventListener('DOMContentLoaded', loadArticles);
+  </script>
+</body>
+</html>

--- a/content/articles/2025-11-historie-ceny.md
+++ b/content/articles/2025-11-historie-ceny.md
@@ -1,0 +1,33 @@
+---
+title: Historie ceny Z.V. Tobolky
+date: 2025-11-06
+author: Redakce
+category: Historie
+excerpt: Cena Z.V. Tobolky je nejvýznamnější ocenění v oblasti českého knihovnictví. Přinášíme historii jejího vzniku a vývoje.
+published: true
+---
+
+# Historie ceny Z.V. Tobolky
+
+Cena Z.V. Tobolky je nejvýznamnější ocenění v oblasti českého knihovnictví. Je udělována od roku 1995 Svazem knihovníků a informačních pracovníků České republiky za mimořádný přínos k rozvoji českého knihovnictví.
+
+## Založení ceny
+
+V roce 1995 byla cena založena na počest **Zdeňka Václava Tobolky** (1874-1951), významného českého knihovníka a bibliografa, který působil jako ředitel Městské knihovny v Praze a významně přispěl k rozvoji českého knihovnického systému.
+
+## Význam ceny
+
+Cena je udělována osobnostem, které se dlouhodobě a mimořádně zasloužily o:
+
+- Rozvoj knihovnické teorie
+- Praxi v knihovnách
+- Vzdělávání knihovníků
+- Organizaci knihovnického oboru
+
+## První laureáti
+
+První udělení ceny proběhlo v roce 1995 a od té doby je každoročně oceňováno několik významných osobností českého knihovnictví.
+
+## Současnost
+
+Cena si udržuje vysokou prestiž a získání ocenění Z.V. Tobolky je považováno za vrchol profesní kariéry v oboru knihovnictví a informačních věd.

--- a/content/articles/2025-11-metodologie-vyzkumu.md
+++ b/content/articles/2025-11-metodologie-vyzkumu.md
@@ -1,0 +1,60 @@
+---
+title: Metodologie tobolkometrického výzkumu
+date: 2025-11-06
+author: Redakce
+category: Metodologie
+excerpt: Podrobný přehled vědeckých metod používaných při analýze knihovnické obce a nositelů ceny Z.V. Tobolky.
+published: true
+---
+
+# Metodologie tobolkometrického výzkumu
+
+Tobolkometrie jako interdisciplinární vědecká oblast využívá řadu osvědčených metodologických přístupů z oblasti bibliometrie, sociologie a datové analýzy.
+
+## Základní principy
+
+Výzkum v oblasti tobolkometrie se opírá o tři základní pilíře:
+
+### 1. Systematický sběr dat
+
+Sběr informací probíhá z následujících zdrojů:
+
+- Veřejně dostupné databáze
+- Odborné publikační systémy
+- Archivní materiály
+- Oficiální dokumenty SKIP ČR
+
+### 2. Strukturovaná analýza
+
+Data jsou analyzována pomocí:
+
+- Deskriptivní statistiky
+- Korelační analýzy
+- Časových řad
+- Obsahové analýzy publikací
+
+### 3. Kvalitativní hodnocení
+
+Kromě kvantitativních metod je kladen důraz na:
+
+- Historický kontext
+- Společenský význam přínosu
+- Dlouhodobý dopad na obor
+
+## Etické principy
+
+Výzkum respektuje:
+
+- Ochranu osobních údajů
+- Transparentnost metod
+- Ověřitelnost výsledků
+- Akademickou integritu
+
+## Výstupy výzkumu
+
+Výsledky tobolkometrického výzkumu slouží k:
+
+- Dokumentaci historie českého knihovnictví
+- Identifikaci trendů v oboru
+- Podpore vzdělávání nových generací knihovníků
+- Prezentaci významu knihovnické profese

--- a/content/pages/o-projektu.md
+++ b/content/pages/o-projektu.md
@@ -1,0 +1,50 @@
+---
+title: O projektu Tobolkometrie
+slug: o-projektu
+description: Informace o projektu vědecké analýzy knihovnické obce
+published: true
+---
+
+# O projektu Tobolkometrie
+
+Tobolkometrie je vědecký projekt zaměřený na **systematickou analýzu české knihovnické obce** se zvláštním důrazem na nositele prestižní **ceny Z.V. Tobolky**.
+
+## Cíle projektu
+
+Projekt si klade za cíl:
+
+- **Dokumentovat historii** českého knihovnictví prostřednictvím analýzy osobností oceněných cenou Z.V. Tobolky
+- **Identifikovat trendy** ve vývoji knihovnické profese a jejích představitelů
+- **Vytvořit strukturovanou databázi** informací o laureátech ceny
+- **Aplikovat vědecké metody** z oblasti bibliometrie a sociologie na analýzu knihovnické komunity
+- **Zpřístupnit poznatky** odborné i laické veřejnosti
+
+## Co je tobolkometrie?
+
+Tobolkometrie je interdisciplinární vědecká oblast, která kombinuje metody:
+
+- **Bibliometrie** - analýza publikační činnosti
+- **Sociologie** - studium profesních komunit
+- **Datové vědy** - zpracování a vizualizace dat
+- **Dějin knihovnictví** - historický kontext
+
+## Proč Tobolkometrie?
+
+Název je odvozen od **Zdeňka Václava Tobolky** (1874-1951), klíčové postavy českého knihovnictví první poloviny 20. století. Jeho jméno nese nejvýznamnější cena v oboru, udělovaná od roku 1995.
+
+## Pro koho je projekt určen?
+
+Projekt je určen pro:
+
+- Knihovníky a informační pracovníky
+- Studenty knihovnictví a informační vědy
+- Výzkumníky v oblasti dějin knihoven
+- Širší odbornou i laickou veřejnost zajímající se o knihovnictví
+
+## Realizace projektu
+
+Projekt realizuje tým výzkumníků a nadšenců pro knihovnictví s využitím moderních technologií a metod datové analýzy.
+
+## Kontakt
+
+Pro dotazy a náměty nás prosím kontaktujte prostřednictvím GitHubu projektu nebo přímo na webových stránkách.

--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@
         <h1 class="font-serif">Tobolkometrie</h1>
         <p>Vědecká analýza knihovnické obce se zaměřením na nositele ceny Z.V. Tobolky</p>
         <div class="button-group">
-          <a href="#drzitele" class="btn btn-primary">Databáze držitelů ceny</a>
+          <a href="clanky.html" class="btn btn-primary">Články a výzkum</a>
           <a href="#o-cene" class="btn btn-secondary">O ceně Z.V. Tobolky</a>
         </div>
       </div>


### PR DESCRIPTION
Implement login-less content management system:
- Add Decap CMS admin interface at /admin/
- Create article listing and detail pages
- Add sample articles in Markdown format
- Create simple page content type
- Add editor documentation in Czech
- Update CLAUDE.md with CMS architecture
- Link articles section from homepage

Features:
- Visual WYSIWYG editor for non-technical users
- GitHub-based authentication and storage
- Automatic deployment via GitHub Pages
- Support for articles, pages, and award recipients
- Category filtering and search-ready structure

Sample content includes:
- Historie ceny Z.V. Tobolky
- Metodologie tobolkometrického výzkumu
- O projektu page

Related to issue #1